### PR TITLE
Update tb3-enabler.py to support macOS 10.12.2

### DIFF
--- a/tb3-enabler.py
+++ b/tb3-enabler.py
@@ -20,9 +20,11 @@ backup = "%s.original" % target
 
 md5_version = {
     "00e2f0eb5db157462a83e4de50583e33": ["10.12.1 (16B2659)"],
+    "ebde660af1f51dc7482551e8d07c62fd": ["10.12.2 (16C67)"],
 }
 md5_patch = {
-    "00e2f0eb5db157462a83e4de50583e33": "a6c2143c2f085c2c104369d7a1adfe03"
+    "00e2f0eb5db157462a83e4de50583e33": "a6c2143c2f085c2c104369d7a1adfe03",
+    "ebde660af1f51dc7482551e8d07c62fd": "2ebb68137da4a1cb0dfc6e6f05be3db2"
 }
 md5_patch_r = dict((v, k) for k, v in md5_patch.items())
 


### PR DESCRIPTION
Manually patched my IOThunderboltFamily kext in 10.12.2, and computed the md5 before and after patching.

Now my output of running the script is:
```
target: patched, 10.12.2 (16C67)
backup: original, 10.12.2 (16C67)
```